### PR TITLE
Add normalise option

### DIFF
--- a/bin/collecticons.js
+++ b/bin/collecticons.js
@@ -30,6 +30,8 @@ program
   .option("--no-preview", "disable the preview")
 
   .option("--catalog-dest <dest>", "destination folder for the catalog. Output disable by default")
+  .option("--normalise", "Normalise icons by scaling them to the height of the highest icon.")
+
   .action(collecticons.process);
 
 program

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,8 @@ function cmdProcess(src, options, finalCb) {
     .pipe(stripGrid('svgGrid'))
     .pipe(iconfont({
       fontName: options.fontName,
-      spawnWoff2: false
+      spawnWoff2: false,
+      normalize: options.normalise
     }))
     // After the font is converted, it emit the glyphs.
     // They are stored because at this point the font file is not on disk yet


### PR DESCRIPTION
@danielfdsilva when using icons of different heights (not ideal, I know) `gulp-svgicons2svgfont` throws the following warning:

```
The provided icons does not have the same height it could lead to unexpected results. Using the normalize option could solve the problem.
```

This allows users to pass the normalize flag down to that dependency. It's spelled the British way to avoid a naming conflict
