### PR TITLE
Replace libxmljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,12 @@
     "gulp-consolidate": "^0.2.0",
     "gulp-iconfont": "^8.0.0",
     "gulp-rename": "^1.2.2",
-    "gulp-xml-transformer": "^1.2.0",
     "lodash": "^4.15.0",
-    "mkpath": "^1.0.0"
+    "mkpath": "^1.0.0",
+    "through2": "^2.0.3",
+    "vinyl-contents-tostring": "^1.0.0",
+    "xmldom": "^0.1.27",
+    "xpath": "0.0.23"
   },
   "devDependencies": {
     "eslint": "^3.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -241,31 +241,36 @@ var stripGrid = function (gridId) {
     } else {
       vinylToString(file, enc)
         .then(xml => {
-          var doc = new xmldom.DOMParser().parseFromString(xml); 
+          var doc = new xmldom.DOMParser().parseFromString(xml);
           var grid = select('//svg:g[@id="' + gridId + '"]', doc, true);
-          var parent = grid.parentNode;
-          parent.removeChild(grid);
-          var transformedXml = new xmldom.XMLSerializer()
-            .serializeToString(doc)
-            .replace(/\r\n/g, '\n');
-          ;
+          if (grid) {
+            // There's a grid, remove it.
+            var parent = grid.parentNode;
+            parent.removeChild(grid);
+            var transformedXml = new xmldom.XMLSerializer()
+              .serializeToString(doc)
+              .replace(/\r\n/g, '\n');
 
-          if (file.isBuffer()) {
-            newFile.contents = new Buffer(transformedXml);
-          } else /* if (file.isStream()) */ {
-            // start the transformation
-            newFile.contents = through();
-            newFile.contents.write(transformedXml);
-            newFile.contents.end();
+            if (file.isBuffer()) {
+              newFile.contents = new Buffer(transformedXml);
+            } else /* if (file.isStream()) */ {
+              // start the transformation
+              newFile.contents = through();
+              newFile.contents.write(transformedXml);
+              newFile.contents.end();
+            }
+
+            // make sure the file goes through the next gulp plugin
+            this.push(newFile);
+          } else {
+            // Do nothing.
+            this.push(file);
           }
-
-          // make sure the file goes through the next gulp plugin
-          this.push(newFile);
           cb();
         })
         .catch(cb);
     }
-  }); 
+  });
 };
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/tests/expected/add.svg
+++ b/tests/expected/add.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">

--- a/tests/fixtures/add_icon/add.svg
+++ b/tests/fixtures/add_icon/add.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px"
 	 width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
 <g id="svgGrid">
 	<line fill="none" stroke="#B35047" x1="32" y1="0" x2="32" y2="512"/>

--- a/tests/grid.js
+++ b/tests/grid.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var cp = require('child_process');
+var Parser = require('xmldom').DOMParser;
 var assert = require('assert');
 var del = require('del');
 var collecticons = path.join(__dirname, '/../bin/collecticons.js');
@@ -17,9 +18,9 @@ describe('testing command grid', function () {
 
     cp.spawn('node', args, {stdio: 'inherit'})
     .on('close', function (code) {
-      assert.equal(
-        fs.readFileSync(path.join(__dirname, '/results/test-grid/add.svg'), {encoding: 'utf8'}),
-        fs.readFileSync(path.join(__dirname, '/expected/add.svg'), {encoding: 'utf8'})
+      assert.deepEqual(
+        new Parser().parseFromString(fs.readFileSync(path.join(__dirname, '/results/test-grid/add.svg'), {encoding: 'utf8'})),
+        new Parser().parseFromString(fs.readFileSync(path.join(__dirname, '/expected/add.svg'), {encoding: 'utf8'}))
       );
       done();
     });

--- a/tests/grid.js
+++ b/tests/grid.js
@@ -18,9 +18,9 @@ describe('testing command grid', function () {
 
     cp.spawn('node', args, {stdio: 'inherit'})
     .on('close', function (code) {
-      assert.deepEqual(
-        new Parser().parseFromString(fs.readFileSync(path.join(__dirname, '/results/test-grid/add.svg'), {encoding: 'utf8'})),
-        new Parser().parseFromString(fs.readFileSync(path.join(__dirname, '/expected/add.svg'), {encoding: 'utf8'}))
+      assert.equal(
+        new Parser().parseFromString(fs.readFileSync(path.join(__dirname, '/results/test-grid/add.svg'), {encoding: 'utf8'})).toString(),
+        new Parser().parseFromString(fs.readFileSync(path.join(__dirname, '/expected/add.svg'), {encoding: 'utf8'})).toString()
       );
       done();
     });


### PR DESCRIPTION
This replaces libxmljs with a pure javascript library (xmldom).
The test fixtures are changed to match the output of xmldom (the output is actually closer to the source input in terms of attributes).

Closed #16 

cc @drewbo @danielfdsilva @anandthakker 

