### PR TITLE
V4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $ collecticons compile --help
   --no-css-class                  disable the css standalone classes
   --preview-dest <dest>           destination folder for the preview (default: "collecticons/")
   --no-preview                    disable the preview
+  --rescale                       normalize icons by scaling them to the height of the highest icon
   --catalog-dest <dest>           destination folder for the catalog. Output disable by default
   --experimental-font-on-catalog  includes the base64 string of the fonts on the catalog. Experimental feature, may change at anytime
   --experimental-disable-styles   disabled the style output. Experimental feature, may change at anytime
@@ -219,11 +220,22 @@ Output destination for the preview file. Default `collecticons/`
 **params.preview**  
 Whether or not to render the preview file. Default `true`
 
+**params.rescale**  
+Whether or not to normalize icons by scaling them to the height of the highest icon. Default `false`
+
 **params.catalogDest**  
 If defined has to be a valid folder path and catalog will be output. Default `undefined`.
 
 **params.noFileOutput**  
 If set to `true` a list of files and their content is returned instead of writing the files to disk. Default `undefined`.
+
+**params.experimentalFontOnCatalog**
+Includes the base64 string of the fonts on the catalog. Default `undefined`.
+Experimental feature, may change at anytime.
+
+**params.experimentalDisableStyles**
+Disables the output of the style files. Default `undefined`.
+Experimental feature, may change at anytime.
 
 ### bundle(params)
 Compiles the collecticons font and zips it. Contains all the used icons, stylesheet and preview.
@@ -233,14 +245,6 @@ Source path for the SVG icons.
 
 **params.destFile**  
 Destination of the zip file.
-
-**params.experimentalFontOnCatalog**
-Includes the base64 string of the fonts on the catalog. Default `undefined`.
-Experimental feature, may change at anytime.
-
-**params.experimentalDisableStyles**
-Disables the output of the style files. Default `undefined`.
-Experimental feature, may change at anytime.
 
 ## Contributing
 You are free to contribute to the project. If you find a bug and/or have a nice idea about a feature feel free to open an issue or submit your own solution. See [DEVELOPMENT.md](DEVELOPMENT.md) for setup instructions.

--- a/bin/collecticons.js
+++ b/bin/collecticons.js
@@ -58,6 +58,7 @@ program
   .option('--no-preview', 'disable the preview')
 
   .option('--catalog-dest <dest>', 'destination folder for the catalog. Output disable by default')
+  .option('--rescale', 'normalize icons by scaling them to the height of the highest icon')
 
   .option('--experimental-font-on-catalog', 'includes the base64 string of the fonts on the catalog. Experimental feature, may change at anytime')
   .option('--experimental-disable-styles', 'disabled the style output. Experimental feature, may change at anytime')

--- a/bin/programs.js
+++ b/bin/programs.js
@@ -26,6 +26,7 @@ async function compileProgram (dirPath, command) {
     'className',
     'previewDest',
     'preview',
+    'rescale',
     'catalogDest',
 
     'experimentalFontOnCatalog',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collecticons-processor",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Processor script for the collecticon icon library",
   "main": "src/index.js",
   "homepage": "https://github.com/developmentseed/collecticons-processor",

--- a/src/core/bundle.js
+++ b/src/core/bundle.js
@@ -30,7 +30,8 @@ async function collecticonsBundle (params) {
     fontDest: './',
     fontTypes: ['woff', 'woff2'],
     previewDest: './',
-    noFileOutput: true
+    noFileOutput: true,
+    rescale: true
   });
 
   if (resultFiles === null) return;

--- a/src/core/compile.js
+++ b/src/core/compile.js
@@ -33,7 +33,8 @@ const defaults = {
   cssClass: true,
 
   previewDest: 'collecticons/',
-  preview: true
+  preview: true,
+  normalize: false
 
   // catalogDest: undefined by default.
 
@@ -79,6 +80,9 @@ const validStyleFormats = ['css', 'sass'];
  *                 Default 'collecticons/'
  * @param {boolean} params.preview Whether or not to render the preview file.
  *                 Default true
+ * @param {boolean} params.rescale Whether or not to normalize icons by scaling
+ *                  them to the height of the highest icon.
+ *                 Default false
  * @param {string} params.catalogDest If defined has to be a valid folder path
  *                 and catalog will be output. Default undefined.
  * @param {boolean} params.noFileOutput If set to true a list of files and their
@@ -110,6 +114,7 @@ async function collecticonsCompile (params) {
     className,
     previewDest,
     preview,
+    rescale,
     catalogDest,
     noFileOutput,
 
@@ -176,7 +181,12 @@ async function collecticonsCompile (params) {
 
   const fonts = await generateFont({
     fontName,
-    icons
+    icons,
+    formatOptions: {
+      svg: {
+        normalize: !!rescale
+      }
+    }
   });
 
   // Store all files to be, so that they can be written to disk.

--- a/src/font-generator.js
+++ b/src/font-generator.js
@@ -12,7 +12,7 @@ const generators = {
       const svgOptions = {
         fontName: options.fontName,
         fontHeight: 1024,
-
+        ...get(options, 'formatOptions.svg', {}),
         log: function () {}
       };
 


### PR DESCRIPTION
Changelog:
- Add `nomalize` option to the compile program. This scales the icons to the height of the highest icon allowing different sized icons to be used in the same library.
- Update docs